### PR TITLE
주소 다음에서 제공하는 우편조회 적용 회원가입에만.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     </properties>
 
     <dependencies>
+
         <dependency>
             <groupId>nz.net.ultraq.thymeleaf</groupId>
             <artifactId>thymeleaf-layout-dialect</artifactId>
@@ -84,7 +85,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/com/project/bookjuck/AuthenticationFacade.java
+++ b/src/main/java/com/project/bookjuck/AuthenticationFacade.java
@@ -2,6 +2,7 @@ package com.project.bookjuck;
 
 import com.project.bookjuck.user.UserMapper;
 import com.project.bookjuck.user.model.UserEntity;
+import com.project.bookjuck.user.model.UserVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -23,4 +24,16 @@ public class AuthenticationFacade {
     public int getLoginUserPk() {
         return getLoginUser() == null ? 0 : getLoginUser().getIuser();
     }
+
+    public UserVO getLoginUser2() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String uid = auth.getName();
+        UserEntity entity = new UserEntity();
+
+        entity.setUid(uid);
+        UserVO vo = mapper.selUser2(entity);
+        vo.cutAddr(vo.getAddr());
+        return vo;
+    }
+
 }

--- a/src/main/java/com/project/bookjuck/user/UserMapper.java
+++ b/src/main/java/com/project/bookjuck/user/UserMapper.java
@@ -1,6 +1,7 @@
 package com.project.bookjuck.user;
 
 import com.project.bookjuck.user.model.UserEntity;
+import com.project.bookjuck.user.model.UserVO;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
@@ -9,4 +10,7 @@ public interface UserMapper {
     UserEntity selUser(UserEntity entity);
     UserEntity selPw(UserEntity entity);
     int updPw(UserEntity entity);
+
+    //주소를 나눠받기위한 개지랄
+    UserVO selUser2(UserEntity entity);
 }

--- a/src/main/java/com/project/bookjuck/user/UserService.java
+++ b/src/main/java/com/project/bookjuck/user/UserService.java
@@ -30,7 +30,8 @@ public class UserService {
 
         UserVO voresult = new UserVO();
         vo.setEmail(voresult.totalEmail(vo.getEmail1(), vo.getEmail2()));
-
+        vo.setAddr(vo.totalAddr());
+        System.out.println(vo.getAddr());
         String hashedUpw = passwordEncoder.encode(vo.getUpw());
         vo.setUpw(hashedUpw);
         try {

--- a/src/main/java/com/project/bookjuck/user/model/UserVO.java
+++ b/src/main/java/com/project/bookjuck/user/model/UserVO.java
@@ -12,10 +12,26 @@ public class UserVO extends UserEntity {
     private String email1;
     private String email2;
 
+    private String addr1;
+    private String addr2;
+
     public String totalEmail(String email1, String email2){
         this.email1 = email1;
         this.email2 = email2;
         return email1 + "@" + email2;
     }
+
+    public String totalAddr(){
+
+        return addr1 +", " + addr2;
+    }
+
+    public void cutAddr(String addr){
+
+        String[] Addrs = addr.split(", ");
+        this.addr1 = Addrs[0];
+        this.addr2 = Addrs[1];
+    }
+
 
 }

--- a/src/main/resources/mappers/UserMapper.xml
+++ b/src/main/resources/mappers/UserMapper.xml
@@ -12,6 +12,7 @@
         </if>
     </select>
 
+
     <insert id="insUser">
         INSERT INTO t_user
             (uid, upw, nm, addr, email, birth, ph, gender)
@@ -33,5 +34,16 @@
         WHERE iuser = ${iuser}
     </select>
 
+<!--고객 주소 나눠받으려고-->
+    <select id="selUser2" resultType="com.project.bookjuck.user.model.UserVO">
+        SELECT * FROM t_user
+        WHERE
+        <if test=" uid != null and uid != '' ">
+            uid = #{uid}
+        </if>
+        <if test=" iuser > 0 ">
+            AND iuser = ${iuser}
+        </if>
+    </select>
 
 </mapper>

--- a/src/main/resources/static/js/user/join.js
+++ b/src/main/resources/static/js/user/join.js
@@ -2,6 +2,7 @@
 
     const joinFrmElem = document.querySelector('#join-frm');
 
+
     let idChkState = 2; //0: 아이디 사용 불가능, 1:아이디 사용가능, 2: 체크 안함
 
     const uidRegex = /^[a-z]+[a-z0-9]{5,20}$/g;
@@ -29,7 +30,7 @@
     };
 
 
-    if (joinFrmElem) {
+    if(joinFrmElem) {
 
         joinFrmElem.addEventListener('submit', (e) => {
             const uid = joinFrmElem.uid.value;
@@ -38,8 +39,9 @@
             const nm = joinFrmElem.nm.value;
             const ph = joinFrmElem.ph.value;
             const birth = joinFrmElem.birth.value;
-            const email = joinFrmElem.email.value;
-
+            const email1 = joinFrmElem.email1.value;
+            const email2 = joinFrmElem.email2.value;
+            const addr2 = joinFrmElem.addr2.value;
 
             console.log(uid);
             console.log(upw);
@@ -47,7 +49,7 @@
             console.log(nm);
             console.log(ph);
             console.log(birth);
-            console.log(email);
+
 
 
             if (!uidRegex.test(uid)) {
@@ -69,7 +71,7 @@
             } else if (!birthRegex.test(birth)) {
                 alert("생일은 - 없이 8자리 로 작성해주세요. ex)19990512");
                 e.preventDefault();
-            } else if (!emailRegex.test(email)) {
+            } else if (!emailRegex.test(email1)) {
                 alert("이메일 양식에 맞추어 입력하세요.");
                 e.preventDefault();
             } else if (idChkState !== 1) {
@@ -82,6 +84,13 @@
                         break;
                 }
                 e.preventDefault();
+            }else if(email2 === "" || email2 === null){
+                e.preventDefault();
+                alert("이메일 주소를 선택해주세요.");
+            }
+            else if(addr2 === "" || addr2 === null){
+                e.preventDefault();
+                alert("상세주소를 입력하세요.");
             }
         });
 
@@ -120,5 +129,20 @@
         }
 
     })
+
+
+    const ps_box = joinFrmElem.querySelector("#addr1");
+
+    ps_box.addEventListener('click', ()=>{
+        new daum.Postcode({
+            oncomplete: function(data) {
+                // 팝업에서 검색결과 항목을 클릭했을때 실행할 코드를 작성하는 부분
+                console.log(data)
+                ps_box.value = data.address;
+            document.querySelector('#addr2').focus();
+            }
+        }).open();
+    })
+
 
 }

--- a/src/main/resources/views/user/join.html
+++ b/src/main/resources/views/user/join.html
@@ -4,6 +4,7 @@
       layout:decorate="temp/loginjoin_layout">
 
 <head>
+    <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <title>회원가입</title>
     <link rel="stylesheet" th:href="@{/css/user/join.css}">
     <!--AT{}는 Standard URL이라고 한다. -->
@@ -47,7 +48,8 @@
             <div><input type="password" maxlength="15" placeholder="비밀번호 확인" id="upw-chk" class="ps_box"></div>
 
             <h4>주소</h4>
-            <div><input type="text" th:field="*{addr}" class="ps_box"></div>
+            <div><input type="text" th:field="*{addr1}" class="ps_box"></div>
+                <div><input type="text" th:field="*{addr2}" class="ps_box" placeholder="상세주소를 입력하여 주세여."></div>
 
             <h4>이메일</h4>
             <div class="colorblue">※비밀번호 분실 시 임시 비밀번호가 이메일로 발송됩니다.</div>

--- a/src/main/resources/views/user/mypage/changeInfo.html
+++ b/src/main/resources/views/user/mypage/changeInfo.html
@@ -42,7 +42,8 @@
                 </form>
 
                 <div class="m-t-10"><b>주소</b></div>
-                <div><input type="text" th:value="${@utils.getLoginUser().getAddr()}" class="text_box"></div>
+                <div><input type="text" th:value="${@utils.getLoginUser2().getAddr1()}" class="text_box"></div>
+                    <div><input type="text" th:value="${@utils.getLoginUser2().getAddr2()}" class="text_box"></div>
 
                 <div class="flex justify_flex_end"><input type="button" value="수정완료" class="change_btn"></div>
                 </form>


### PR DESCRIPTION
회원가입 시 주소값을 다음에서 제공하는 팝업창에서 제공받고, 인풋 창을 하나 더 추가하여 상세주소를 받도록 했습니다. 
주소값 수정처리를 해야하는데, 
이메일 인증이 되지 않으면 서브밋 처리를 막는 방법이 어떨지 생각해보았습니다. 

+ 저 이메일 인증이 안보내집니다 ㅠㅠ 메일 인증을 눌러도 제 메일로 안오는뒈.... 갑자기.. 
